### PR TITLE
Refactor/merge errors with tag

### DIFF
--- a/internal/controller/sharded.go
+++ b/internal/controller/sharded.go
@@ -48,14 +48,13 @@ func (r *StCtrlErrSet) AsResult() (ctrl.Result, error) {
 	if r.Update != nil {
 		errMap["update-status"] = r.Update
 	}
-	mergedErr := util.MergeErrorsWithTag(errMap)
-	if mergedErr == nil {
+	if len(errMap) == 0 {
 		if updateConflict {
 			return ctrl.Result{Requeue: true}, nil
 		} else {
 			return ctrl.Result{}, nil
 		}
 	} else {
-		return ctrl.Result{Requeue: true}, mergedErr
+		return ctrl.Result{Requeue: true}, &util.MultiTaggedError{Errors: errMap}
 	}
 }

--- a/internal/controller/sharded_test.go
+++ b/internal/controller/sharded_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	update_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestAsResult(t *testing.T) {
+	// Test case 1: No errors
+	errSet := StCtrlErrSet{}
+	result, err := errSet.AsResult()
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Test case 2: Update conflict error
+	statusErr := update_errors.StatusError{ErrStatus: metav1.Status{
+		Reason: metav1.StatusReasonConflict,
+		Code:   http.StatusConflict,
+	}}
+	errSet = StCtrlErrSet{Update: error(&statusErr)}
+	result, err = errSet.AsResult()
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{Requeue: true}, result)
+
+	// Test case 3: Other Errors
+	errSet = StCtrlErrSet{
+		Rec:    errors.New("reconciliation error"),
+		Sync:   errors.New("sync error"),
+		Update: errors.New("sync error"),
+	}
+	result, err = errSet.AsResult()
+	assert.Error(t, err)
+	assert.Equal(t, ctrl.Result{Requeue: true}, result)
+}

--- a/internal/util/mutierror.go
+++ b/internal/util/mutierror.go
@@ -99,17 +99,3 @@ func (e *MultiTaggedError) Error() string {
 	}
 	return strings.Join(errStrs, "; ")
 }
-
-// MergeErrorsWithTag merges multiple errors into one with tags.
-func MergeErrorsWithTag(errors map[string]error) *MultiTaggedError {
-	errMap := make(map[string]error)
-	for tag, err := range errors {
-		if err != nil {
-			errMap[tag] = err
-		}
-	}
-	if len(errMap) == 0 {
-		return nil
-	}
-	return &MultiTaggedError{Errors: errMap}
-}

--- a/internal/util/mutierror_test.go
+++ b/internal/util/mutierror_test.go
@@ -20,9 +20,9 @@ package util
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/strings/slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeErrors(t *testing.T) {
@@ -37,24 +37,4 @@ func TestMergeErrors(t *testing.T) {
 
 	err4 := MergeErrors(nil, nil)
 	assert.Nil(t, err4)
-}
-
-func TestMergeErrorsWithTags(t *testing.T) {
-	err1 := MergeErrorsWithTag(map[string]error{
-		"tag1": fmt.Errorf("foo"),
-		"tag2": fmt.Errorf("bar"),
-	})
-	assert.True(t, slices.Contains([]string{"[tag1] foo; [tag2] bar", "[tag2] bar; [tag1] foo"}, err1.Error()))
-
-	err2 := MergeErrorsWithTag(map[string]error{
-		"tag1": fmt.Errorf("foo"),
-		"tag2": nil,
-	})
-	assert.Equal(t, "[tag1] foo", err2.Error())
-
-	err3 := MergeErrorsWithTag(map[string]error{
-		"tag1": nil,
-		"tag2": nil,
-	})
-	assert.Nil(t, err3)
 }


### PR DESCRIPTION
Currently,  the method `MergeErrorsWithTag` is only used in `AsResult` and it seems unnecessary. I add an unit test to cover the `AsResult` method and refactor it.  Based on pr #40 